### PR TITLE
Add basic user registration

### DIFF
--- a/src/main/java/com/example/authservice/AuthController.java
+++ b/src/main/java/com/example/authservice/AuthController.java
@@ -1,0 +1,32 @@
+package com.example.authservice;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final UserRepository userRepository;
+    private final org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
+
+    @PostMapping("/register")
+    public ResponseEntity<User> register(@RequestBody RegisterRequest request) {
+        if (userRepository.existsByUsername(request.username())) {
+            return ResponseEntity.badRequest().build();
+        }
+        User user = new User();
+        user.setUsername(request.username());
+        user.setPassword(passwordEncoder.encode(request.password()));
+        user.getRoles().add(Role.USER);
+        User saved = userRepository.save(user);
+        return ResponseEntity.ok(saved);
+    }
+
+    public record RegisterRequest(String username, String password) {}
+}

--- a/src/main/java/com/example/authservice/Role.java
+++ b/src/main/java/com/example/authservice/Role.java
@@ -1,0 +1,7 @@
+package com.example.authservice;
+
+public enum Role {
+    USER,
+    ADMIN,
+    MODERATOR
+}

--- a/src/main/java/com/example/authservice/SecurityConfig.java
+++ b/src/main/java/com/example/authservice/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.example.authservice;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/example/authservice/User.java
+++ b/src/main/java/com/example/authservice/User.java
@@ -1,0 +1,29 @@
+package com.example.authservice;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    private Set<Role> roles = new HashSet<>();
+}

--- a/src/main/java/com/example/authservice/UserRepository.java
+++ b/src/main/java/com/example/authservice/UserRepository.java
@@ -1,0 +1,10 @@
+package com.example.authservice;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+    boolean existsByUsername(String username);
+}

--- a/src/test/java/com/example/authservice/AuthControllerIntegrationTests.java
+++ b/src/test/java/com/example/authservice/AuthControllerIntegrationTests.java
@@ -1,0 +1,49 @@
+package com.example.authservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthControllerIntegrationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Test
+    void registerCreatesUser() throws Exception {
+        mockMvc.perform(post("/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"alice\",\"password\":\"password\"}"))
+                .andExpect(status().isOk());
+
+        assertThat(userRepository.findByUsername("alice")).isPresent();
+    }
+
+    @Test
+    void passwordIsHashed() throws Exception {
+        mockMvc.perform(post("/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"bob\",\"password\":\"secret\"}"))
+                .andExpect(status().isOk());
+
+        User user = userRepository.findByUsername("bob").orElseThrow();
+        assertThat(user.getPassword()).isNotEqualTo("secret");
+        assertThat(passwordEncoder.matches("secret", user.getPassword())).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add `User` entity and `Role` enum
- create a `UserRepository`
- expose `/auth/register` endpoint for creating users
- hash passwords with `BCryptPasswordEncoder`
- add integration tests covering registration and password hashing

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684600e8c0b48333b11ac9183992d8f7