### PR TITLE
Implement JWT login and refresh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,24 @@
         </dependency>
 
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.12.3</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.12.3</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/example/authservice/AuthController.java
+++ b/src/main/java/com/example/authservice/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.authservice;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ public class AuthController {
 
     private final UserRepository userRepository;
     private final org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
+    private final JwtService jwtService;
 
     @PostMapping("/register")
     public ResponseEntity<User> register(@RequestBody RegisterRequest request) {
@@ -28,5 +30,34 @@ public class AuthController {
         return ResponseEntity.ok(saved);
     }
 
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        User user = userRepository.findByUsername(request.username()).orElse(null);
+        if (user == null || !passwordEncoder.matches(request.password(), user.getPassword())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String accessToken = jwtService.generateAccessToken(user);
+        String refreshToken = jwtService.generateRefreshToken(user);
+        return ResponseEntity.ok(new LoginResponse(accessToken, refreshToken));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<LoginResponse> refresh(@RequestBody RefreshRequest request) {
+        if (!jwtService.validate(request.refreshToken())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String username = jwtService.extractUsername(request.refreshToken());
+        User user = userRepository.findByUsername(username).orElse(null);
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String accessToken = jwtService.generateAccessToken(user);
+        String refreshToken = jwtService.generateRefreshToken(user);
+        return ResponseEntity.ok(new LoginResponse(accessToken, refreshToken));
+    }
+
     public record RegisterRequest(String username, String password) {}
+    public record LoginRequest(String username, String password) {}
+    public record LoginResponse(String accessToken, String refreshToken) {}
+    public record RefreshRequest(String refreshToken) {}
 }

--- a/src/main/java/com/example/authservice/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/authservice/JwtAuthenticationFilter.java
@@ -1,0 +1,41 @@
+package com.example.authservice;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            if (jwtService.validate(token)) {
+                String username = jwtService.extractUsername(token);
+                userRepository.findByUsername(username).ifPresent(user -> {
+                    UsernamePasswordAuthenticationToken auth =
+                            new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                });
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/authservice/JwtService.java
+++ b/src/main/java/com/example/authservice/JwtService.java
@@ -1,0 +1,55 @@
+package com.example.authservice;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.Date;
+
+@Service
+public class JwtService {
+
+    private Key key;
+
+    @PostConstruct
+    void init() {
+        // In a real application the secret should come from configuration
+        this.key = Keys.hmacShaKeyFor("change-me-change-me-change-me-change-me".getBytes());
+    }
+
+    public String generateAccessToken(User user) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+                .subject(user.getUsername())
+                .claim("roles", user.getRoles())
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + 30 * 60 * 1000))
+                .signWith(key)
+                .compact();
+    }
+
+    public String generateRefreshToken(User user) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+                .subject(user.getUsername())
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + 7L * 24 * 60 * 60 * 1000))
+                .signWith(key)
+                .compact();
+    }
+
+    public boolean validate(String token) {
+        try {
+            Jwts.parser().verifyWith(key).build().parse(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String extractUsername(String token) {
+        return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload().getSubject();
+    }
+}

--- a/src/main/java/com/example/authservice/SecurityConfig.java
+++ b/src/main/java/com/example/authservice/SecurityConfig.java
@@ -2,19 +2,29 @@ package com.example.authservice;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
-            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/auth/login", "/auth/register", "/auth/refresh", "/h2-console/**").permitAll()
+                    .anyRequest().authenticated())
+            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/com/example/authservice/User.java
+++ b/src/main/java/com/example/authservice/User.java
@@ -4,6 +4,10 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -12,7 +16,7 @@ import java.util.Set;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(of = "id")
-public class User {
+public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -26,4 +30,31 @@ public class User {
     @ElementCollection(fetch = FetchType.EAGER)
     @Enumerated(EnumType.STRING)
     private Set<Role> roles = new HashSet<>();
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return roles.stream()
+                .map(r -> new SimpleGrantedAuthority("ROLE_" + r.name()))
+                .toList();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/test/java/com/example/authservice/JwtAuthenticationFilterTests.java
+++ b/src/test/java/com/example/authservice/JwtAuthenticationFilterTests.java
@@ -1,0 +1,51 @@
+package com.example.authservice;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class JwtAuthenticationFilterTests {
+
+    @Autowired
+    JwtService jwtService;
+    @Autowired
+    JwtAuthenticationFilter filter;
+    @Autowired
+    UserRepository userRepository;
+
+    @AfterEach
+    void clearContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void filterAuthenticatesValidToken() throws Exception {
+        User user = new User();
+        user.setUsername("joe");
+        user.setPassword("pass");
+        user.getRoles().add(Role.USER);
+        userRepository.save(user);
+        String token = jwtService.generateAccessToken(user);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain chain = Mockito.mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getName()).isEqualTo("joe");
+        verify(chain).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/example/authservice/JwtServiceTests.java
+++ b/src/test/java/com/example/authservice/JwtServiceTests.java
@@ -1,0 +1,23 @@
+package com.example.authservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class JwtServiceTests {
+
+    @Autowired
+    JwtService jwtService;
+
+    @Test
+    void generatedTokenContainsUsername() {
+        User user = new User();
+        user.setUsername("alice");
+        String token = jwtService.generateAccessToken(user);
+        assertThat(jwtService.validate(token)).isTrue();
+        assertThat(jwtService.extractUsername(token)).isEqualTo("alice");
+    }
+}


### PR DESCRIPTION
## Summary
- add jjwt dependencies for token support
- create `JwtService` for generating and validating tokens
- implement `/auth/login` and `/auth/refresh` endpoints
- add `JwtAuthenticationFilter` and secure requests via filter
- configure security filter chain to use JWT
- implement unit tests for the service and filter

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684602245ca48333a6140e7bf9f3129e