### PR TITLE
Add simple HTML UI for registration and login

### DIFF
--- a/src/main/java/com/example/authservice/SecurityConfig.java
+++ b/src/main/java/com/example/authservice/SecurityConfig.java
@@ -22,6 +22,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
+                    .requestMatchers("/", "/index.html", "/register", "/login").permitAll()
                     .requestMatchers("/auth/login", "/auth/register", "/auth/refresh", "/h2-console/**").permitAll()
                     .anyRequest().authenticated())
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Auth Service</title>
+</head>
+<body>
+<h1>Auth Service Demo</h1>
+<ul>
+    <li><a href="/register">Register</a></li>
+    <li><a href="/login">Login</a></li>
+</ul>
+</body>
+</html>

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+<h1>Login</h1>
+<form id="loginForm">
+    <label>
+        Username:
+        <input type="text" id="username" required>
+    </label><br>
+    <label>
+        Password:
+        <input type="password" id="password" required>
+    </label><br>
+    <button type="submit">Login</button>
+</form>
+<pre id="result"></pre>
+<p><a href="/register">Need an account? Register</a></p>
+<script>
+    document.getElementById('loginForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const res = await fetch('/auth/login', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({username: username.value, password: password.value})
+        });
+        if (res.ok) {
+            const data = await res.json();
+            document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+        } else {
+            document.getElementById('result').textContent = 'Login failed';
+        }
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/static/register.html
+++ b/src/main/resources/static/register.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+</head>
+<body>
+<h1>Register</h1>
+<form id="registerForm">
+    <label>
+        Username:
+        <input type="text" id="username" required>
+    </label><br>
+    <label>
+        Password:
+        <input type="password" id="password" required>
+    </label><br>
+    <button type="submit">Register</button>
+</form>
+<p id="result"></p>
+<p><a href="/login">Already registered? Login</a></p>
+<script>
+    document.getElementById('registerForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const res = await fetch('/auth/register', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({username: username.value, password: password.value})
+        });
+        if (res.ok) {
+            document.getElementById('result').textContent = 'Registration successful!';
+        } else {
+            document.getElementById('result').textContent = 'Registration failed';
+        }
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expose `/`, `/register` and `/login` pages
- allow anonymous access to new endpoints
- add minimal HTML forms that call existing auth APIs

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684603108148833398a3aa501a2a2274