### PR TITLE
Add dashboard page and login redirect

### DIFF
--- a/src/main/java/com/example/authservice/SecurityConfig.java
+++ b/src/main/java/com/example/authservice/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/", "/index.html", "/register.html", "/login.html").permitAll()
+                    .requestMatchers("/", "/index.html", "/register.html", "/login.html", "/dashboard.html").permitAll()
                     .requestMatchers("/auth/login", "/auth/register", "/auth/refresh", "/h2-console/**").permitAll()
                     .anyRequest().authenticated())
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Dashboard</title>
+    <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+<div class="container">
+    <h1>Dashboard</h1>
+    <p>You are logged in.</p>
+    <button id="logout">Logout</button>
+</div>
+<script>
+    document.getElementById('logout').addEventListener('click', () => {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login.html';
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -11,6 +11,7 @@
     <ul>
         <li><a href="/register.html">Register</a></li>
         <li><a href="/login.html">Login</a></li>
+        <li><a href="/dashboard.html">Dashboard</a></li>
     </ul>
 </div>
 </body>

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -32,7 +32,9 @@
         });
         if (res.ok) {
             const data = await res.json();
-            document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+            localStorage.setItem('accessToken', data.accessToken);
+            localStorage.setItem('refreshToken', data.refreshToken);
+            window.location.href = '/dashboard.html';
         } else {
             document.getElementById('result').textContent = 'Login failed';
         }


### PR DESCRIPTION
## Summary
- add a dashboard page with logout button
- after login store tokens and redirect to dashboard
- include dashboard link on home page
- update security config to allow dashboard page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68460ebbd26483338580541bb3c692c2