### PR TITLE
Add token blacklist and event logging

### DIFF
--- a/src/main/java/com/example/authservice/AuthController.java
+++ b/src/main/java/com/example/authservice/AuthController.java
@@ -7,6 +7,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.time.Instant;
+
+import com.example.authservice.EventLog;
+import com.example.authservice.EventType;
+import com.example.authservice.TokenBlacklistService;
+import com.example.authservice.EventLogRepository;
 
 @RestController
 @RequestMapping("/auth")
@@ -16,6 +22,8 @@ public class AuthController {
     private final UserRepository userRepository;
     private final org.springframework.security.crypto.password.PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final TokenBlacklistService blacklistService;
+    private final EventLogRepository eventLogRepository;
 
     @PostMapping("/register")
     public ResponseEntity<User> register(@RequestBody RegisterRequest request) {
@@ -38,12 +46,13 @@ public class AuthController {
         }
         String accessToken = jwtService.generateAccessToken(user);
         String refreshToken = jwtService.generateRefreshToken(user);
+        logEvent(user.getUsername(), EventType.LOGIN);
         return ResponseEntity.ok(new LoginResponse(accessToken, refreshToken));
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<LoginResponse> refresh(@RequestBody RefreshRequest request) {
-        if (!jwtService.validate(request.refreshToken())) {
+        if (!jwtService.validate(request.refreshToken()) || blacklistService.isRevoked(request.refreshToken())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
         String username = jwtService.extractUsername(request.refreshToken());
@@ -53,11 +62,31 @@ public class AuthController {
         }
         String accessToken = jwtService.generateAccessToken(user);
         String refreshToken = jwtService.generateRefreshToken(user);
+        logEvent(username, EventType.LOGIN);
         return ResponseEntity.ok(new LoginResponse(accessToken, refreshToken));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@RequestBody RefreshRequest request) {
+        if (!jwtService.validate(request.refreshToken())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String username = jwtService.extractUsername(request.refreshToken());
+        blacklistService.revokeToken(request.refreshToken(), jwtService.extractExpiration(request.refreshToken()));
+        logEvent(username, EventType.LOGOUT);
+        return ResponseEntity.ok().build();
     }
 
     public record RegisterRequest(String username, String password) {}
     public record LoginRequest(String username, String password) {}
     public record LoginResponse(String accessToken, String refreshToken) {}
     public record RefreshRequest(String refreshToken) {}
+
+    private void logEvent(String username, EventType type) {
+        EventLog log = new EventLog();
+        log.setUsername(username);
+        log.setEventType(type);
+        log.setTimestamp(Instant.now());
+        eventLogRepository.save(log);
+    }
 }

--- a/src/main/java/com/example/authservice/EventLog.java
+++ b/src/main/java/com/example/authservice/EventLog.java
@@ -1,0 +1,22 @@
+package com.example.authservice;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class EventLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+
+    @Enumerated(EnumType.STRING)
+    private EventType eventType;
+
+    private Instant timestamp;
+}

--- a/src/main/java/com/example/authservice/EventLogRepository.java
+++ b/src/main/java/com/example/authservice/EventLogRepository.java
@@ -1,0 +1,6 @@
+package com.example.authservice;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventLogRepository extends JpaRepository<EventLog, Long> {
+}

--- a/src/main/java/com/example/authservice/EventType.java
+++ b/src/main/java/com/example/authservice/EventType.java
@@ -1,0 +1,7 @@
+package com.example.authservice;
+
+public enum EventType {
+    LOGIN,
+    LOGOUT,
+    ACCESS
+}

--- a/src/main/java/com/example/authservice/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/authservice/JwtAuthenticationFilter.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import com.example.authservice.TokenBlacklistService;
 
 @Component
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserRepository userRepository;
+    private final TokenBlacklistService blacklistService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -26,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String header = request.getHeader("Authorization");
         if (header != null && header.startsWith("Bearer ")) {
             String token = header.substring(7);
-            if (jwtService.validate(token)) {
+            if (jwtService.validate(token) && !blacklistService.isRevoked(token)) {
                 String username = jwtService.extractUsername(token);
                 userRepository.findByUsername(username).ifPresent(user -> {
                     UsernamePasswordAuthenticationToken auth =

--- a/src/main/java/com/example/authservice/JwtService.java
+++ b/src/main/java/com/example/authservice/JwtService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 
 import java.security.Key;
 import java.util.Date;
+import java.time.Instant;
 
 @Service
 public class JwtService {
@@ -51,5 +52,10 @@ public class JwtService {
 
     public String extractUsername(String token) {
         return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload().getSubject();
+    }
+
+    public Instant extractExpiration(String token) {
+        Date exp = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload().getExpiration();
+        return exp.toInstant();
     }
 }

--- a/src/main/java/com/example/authservice/RevokedToken.java
+++ b/src/main/java/com/example/authservice/RevokedToken.java
@@ -1,0 +1,20 @@
+package com.example.authservice;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.Instant;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class RevokedToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 512)
+    private String token;
+
+    private Instant expiresAt;
+}

--- a/src/main/java/com/example/authservice/RevokedTokenRepository.java
+++ b/src/main/java/com/example/authservice/RevokedTokenRepository.java
@@ -1,0 +1,7 @@
+package com.example.authservice;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RevokedTokenRepository extends JpaRepository<RevokedToken, Long> {
+    boolean existsByToken(String token);
+}

--- a/src/main/java/com/example/authservice/TokenBlacklistService.java
+++ b/src/main/java/com/example/authservice/TokenBlacklistService.java
@@ -1,0 +1,24 @@
+package com.example.authservice;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+    private final RevokedTokenRepository repository;
+
+    public void revokeToken(String token, Instant expiresAt) {
+        RevokedToken revoked = new RevokedToken();
+        revoked.setToken(token);
+        revoked.setExpiresAt(expiresAt);
+        repository.save(revoked);
+    }
+
+    public boolean isRevoked(String token) {
+        return repository.existsByToken(token);
+    }
+}

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -12,7 +12,15 @@
     <button id="logout">Logout</button>
 </div>
 <script>
-    document.getElementById('logout').addEventListener('click', () => {
+    document.getElementById('logout').addEventListener('click', async () => {
+        const refresh = localStorage.getItem('refreshToken');
+        if (refresh) {
+            await fetch('/auth/logout', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({refreshToken: refresh})
+            });
+        }
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
         window.location.href = '/login.html';

--- a/src/test/java/com/example/authservice/EventLoggingTests.java
+++ b/src/test/java/com/example/authservice/EventLoggingTests.java
@@ -1,0 +1,41 @@
+package com.example.authservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class EventLoggingTests {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    EventLogRepository logRepository;
+
+    @Test
+    void loginCreatesEventLog() throws Exception {
+        User user = new User();
+        user.setUsername("logger");
+        user.setPassword("pass");
+        user.getRoles().add(Role.USER);
+        userRepository.save(user);
+
+        mockMvc.perform(post("/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"logger\",\"password\":\"pass\"}"))
+                .andExpect(status().isOk());
+
+        assertThat(logRepository.findAll().stream()
+                .anyMatch(l -> l.getUsername().equals("logger") && l.getEventType() == EventType.LOGIN)).isTrue();
+    }
+}

--- a/src/test/java/com/example/authservice/LogoutIntegrationTests.java
+++ b/src/test/java/com/example/authservice/LogoutIntegrationTests.java
@@ -1,0 +1,44 @@
+package com.example.authservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class LogoutIntegrationTests {
+
+    @Autowired
+    MockMvc mockMvc;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    JwtService jwtService;
+    @Autowired
+    RevokedTokenRepository revokedTokenRepository;
+
+    @Test
+    void logoutRevokesToken() throws Exception {
+        User user = new User();
+        user.setUsername("logoutuser");
+        user.setPassword("pass");
+        user.getRoles().add(Role.USER);
+        userRepository.save(user);
+        String refresh = jwtService.generateRefreshToken(user);
+
+        mockMvc.perform(post("/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"refreshToken\":\"" + refresh + "\"}"))
+                .andExpect(status().isOk());
+
+        assertThat(revokedTokenRepository.existsByToken(refresh)).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- add a database-backed blacklist for revoked tokens
- log login and logout events in new `EventLog` entity
- expose `/auth/logout` endpoint and blacklist refresh tokens
- reject blacklisted JWTs in the authentication filter
- update dashboard to call the new logout endpoint
- add tests for logout, blacklist behaviour and event logging

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68461260802c8333adb72a93f89ede61